### PR TITLE
Fix: SkipList find()

### DIFF
--- a/Chapter04/src/skip_list.rs
+++ b/Chapter04/src/skip_list.rs
@@ -79,7 +79,7 @@ impl BestTransactionLog {
                 let node = head.clone();
                 let mut result = None;
                 loop {
-                    if node.borrow().next[start_level].is_some() {
+                    if node.borrow().next[start_level].is_none() {
                         break;
                     }
                     start_level -= 1;


### PR DESCRIPTION
Fixes `chapter04/src/skip_list.rs` L:82 from `is_some()` to `is_none()`, as loop should break when list is exhausted.